### PR TITLE
VER3-479 Add a display when solve for sample size and correct the tab…

### DIFF
--- a/src/app/study-form/calculate/calculate.component.html
+++ b/src/app/study-form/calculate/calculate.component.html
@@ -10,9 +10,9 @@
   <div class="table-responsive">
     <table class="table">
       <tr>
-        <th *ngIf="isPower()">Power</th>
-        <th *ngIf="isSamplesize()">Target Power</th>
+        <th>Power</th>
         <th>Total Sample Size</th>
+        <th *ngIf="isSamplesize()">Target Power</th>
         <th>Means Scale Factor</th>
         <th>Variability Scale Factor</th>
         <th>Test</th>
@@ -22,12 +22,12 @@
           (click)="showDetail(getOutput(result), i, result.model.total_n)"
           [class] = "rowStyle(i)"
           [attr.id]="'result_display_row_'+i">
-        <td *ngIf="isPower() && !error(result)">{{result.power}}</td>
-        <td *ngIf="isPower() && error(result)">{{result.power}} {{result.model.errors}}</td>
-        <td *ngIf="isSamplesize()">{{result.model.target_power}}</td>
-        <td *ngIf="isPower()">{{result.model.total_n}}</td>
+        <td *ngIf="!error(result)">{{result.power}}</td>
+        <td *ngIf="error(result)">{{result.power}} {{result.model.errors}}</td>
         <td *ngIf="isSamplesize() && !error(result)">{{result.samplesize}}</td>
         <td *ngIf="isSamplesize() && error(result)">{{result.model.errors}}</td>
+        <td *ngIf="isPower()">{{result.model.total_n}}</td>
+        <td *ngIf="isSamplesize()">{{result.model.target_power}}</td>
         <td>{{ result.model.means_scale_factor }}</td>
         <td>{{ result.model.variance_scale_factor }}</td>
         <td>{{ result.model.test }}</td>

--- a/src/app/study-form/calculate/calculate.component.ts
+++ b/src/app/study-form/calculate/calculate.component.ts
@@ -181,13 +181,11 @@ export class CalculateComponent implements OnInit, OnDestroy {
   }
 
   getOutput(result) {
-    let value = result.test;
-    if (!isNullOrUndefined(result.power)) {
+    let value = null;
+    if (result.model.errors.length === 0) {
       value = result.power;
-    } else if (!isNullOrUndefined(result.samplesize)) {
-      value = result.samplesize;
     } else {
-      const errors = this.resultString['model']['errors'];
+      const errors = result.model.errors;
       for (const key in errors) {
         if (errors[key]['errorname'] === value) {
           value = errors[key]['errormessage'];
@@ -283,8 +281,8 @@ export class CalculateComponent implements OnInit, OnDestroy {
   }
 
   error(result) {
-    if ( !isNullOrUndefined(result['model']['errors'])
-      && result['model']['errors'].length > 0) {
+    if ( !isNullOrUndefined(result.model.errors.length)
+      && result.model.errors.length > 0) {
       return true;
     } else {
       return false;


### PR DESCRIPTION
I have spoken to Qian and confirmed that no matter users solve for sample size or power, the result should always contain power. 

The power when solving for sample size is actual power. <- this power is not included in the result from the backend now.